### PR TITLE
fix: configure vite swc parser and dev server package

### DIFF
--- a/dev-server/package.json
+++ b/dev-server/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "dev-server",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --config ../vite.config.ts"
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,13 @@ export default defineConfig(({ mode }) => ({
     port: 8080,
   },
   plugins: [
-    react(),
+    react({
+      parser: {
+        syntax: "typescript",
+        tsx: true,
+      },
+      sourceType: "module",
+    }),
     mode === 'development' &&
     componentTagger(),
   ].filter(Boolean),


### PR DESCRIPTION
## Summary
- set Vite's React SWC plugin to explicitly use module parser mode
- add dev-server package.json pointing to root vite config

## Testing
- `npm test`
- `npm run lint` *(fails: no-empty-object-type, no-duplicate-imports, no-require-imports)*
- `npm run dev`
- `npm --prefix dev-server run dev`


------
https://chatgpt.com/codex/tasks/task_e_68bac4fa5f10832aa101ade6a9d012ac