### PR TITLE
Use Number.isNaN for kiosk courseId validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,7 @@ MCQ,What is 2+2?,"1|2|3|4",3,,Example explanation,math
 ```
 
 `choices` values should be separated by `|`.
+
+## Kiosk Course API
+
+`GET /api/kiosk/course/:courseId` returns blocks for a published course. The `courseId` parameter must be a valid number; non-numeric values result in a `400 Invalid courseId` response.

--- a/src/api/kiosk/course/[courseId].ts
+++ b/src/api/kiosk/course/[courseId].ts
@@ -10,7 +10,7 @@ export default async function handler(req: Request, res: Response) {
   }
 
   const courseId = Number(req.params.courseId);
-  if (!courseId) {
+  if (Number.isNaN(courseId)) {
     res.status(400).json({ error: 'Invalid courseId' });
     return;
   }

--- a/src/api/kiosk/course/__tests__/courseId.test.ts
+++ b/src/api/kiosk/course/__tests__/courseId.test.ts
@@ -1,0 +1,20 @@
+import type { Request, Response } from 'express';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/db', () => ({ db: {}, default: {} }));
+
+import handler from '@/api/kiosk/course/[courseId]';
+
+describe('kiosk course handler', () => {
+  it('returns 400 for non-numeric courseId', async () => {
+    const req = { method: 'GET', params: { courseId: 'abc' } } as unknown as Request;
+    const json = vi.fn();
+    const status = vi.fn().mockReturnValue({ json });
+    const res = { status } as unknown as Response;
+
+    await handler(req, res);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({ error: 'Invalid courseId' });
+  });
+});


### PR DESCRIPTION
## Summary
- validate kiosk course requests using Number.isNaN
- document kiosk course API
- add unit test for non-numeric courseId

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, etc.)*
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bac9ff90f4832aaff7235cea3b75b1