### PR TITLE
refactor upload handler imports

### DIFF
--- a/src/api/content/upload.ts
+++ b/src/api/content/upload.ts
@@ -1,7 +1,5 @@
 
 import type { Request, Response } from 'express';
-import formidable, { File } from 'formidable';
-import type { NextApiRequest, NextApiResponse } from 'next';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import fs from 'fs';
 import path from 'path';
@@ -20,7 +18,6 @@ export default async function handler(req: Request, res: Response) {
     const [fields, files] = (await form.parse(req)) as [Fields, Files];
     const blockId = parseInt(fields.blockId?.toString() ?? '', 10);
     const durationMinutes = fields.durationMinutes ? parseInt(fields.durationMinutes.toString(), 10) : null;
-    const file = files.file as File | File[] | undefined;
     const file = (files as Files & { file?: File | File[] }).file;
     
     if (!blockId || !file) {


### PR DESCRIPTION
## Summary
- streamline formidable imports
- drop unused Next.js API types and redundant file variable

## Testing
- `npm run build:api` *(fails: Duplicate identifier 'db', Cannot find module 'next')*
- `npm test -- --run`
- `npm run lint` *(fails: '@/db' import is duplicated, 'db' is already defined)*

------
https://chatgpt.com/codex/tasks/task_e_68baca02b2f8832abfce28bcd879f039