### PR TITLE
refactor: clean up imports in reorder handler

### DIFF
--- a/src/api/blocks/reorder.ts
+++ b/src/api/blocks/reorder.ts
@@ -1,8 +1,5 @@
-
 import type { Request, Response } from 'express';
-import { db } from '@/db'; // TODO: implement database connection
-import type { NextApiRequest, NextApiResponse } from 'next';
-import db from '@/db';
+import { db } from '@/db';
 import { courseBlocks } from '@/db/schema';
 import { eq } from 'drizzle-orm';
 


### PR DESCRIPTION
## Summary
- drop unused Next.js request/response types
- remove duplicate `db` import in reorder handler

## Testing
- `npm run lint` *(fails: '✖ 18 problems')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baca03b9c8832abf0943733f98e4e9