### PR TITLE
refactor kiosk cohort loader

### DIFF
--- a/src/api/content/upload.ts
+++ b/src/api/content/upload.ts
@@ -18,7 +18,6 @@ export default async function handler(req: Request, res: Response) {
     const [fields, files] = (await form.parse(req)) as [Fields, Files];
     const blockId = parseInt(fields.blockId?.toString() ?? '', 10);
     const durationMinutes = fields.durationMinutes ? parseInt(fields.durationMinutes.toString(), 10) : null;
-    const file = files.file as File | File[] | undefined;
     const file = (files as Files & { file?: File | File[] }).file;
 
     

--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -14,6 +14,22 @@ const Kiosk = () => {
 
   const [badgeId, setBadgeId] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Temp cohort loader to mirror real kiosk behaviour
+  const loadCohort = async () => {
+    try {
+      // In the real kiosk this would load cohort details
+      await fetch('/api/kiosk/cohort');
+    } catch (err) {
+      console.error(err);
+    } finally {
+      // no-op: placeholder for any cleanup if needed
+    }
+  };
+
+  useEffect(() => {
+    loadCohort();
+  }, []);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- add loadCohort helper and effect stub in Kiosk page
- fix duplicate variable declaration in content upload handler

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68badbabfc30832aa7a0579be5858ff7