### PR TITLE
remove redundant auth import from dashboard test

### DIFF
--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -4,8 +4,6 @@ import { vi } from 'vitest';
 
 import Dashboard from '@/pages/Dashboard';
 import { useAuth, type UserRole } from '@/lib/use-auth';
-import { type UserRole, useAuth } from '@/lib/auth';
-
 
 // Mock hooks and contexts used within Dashboard
 vi.mock('@/hooks/use-toast', () => ({


### PR DESCRIPTION
## Summary
- fix Dashboard test to import UserRole and useAuth only from `@/lib/use-auth`

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68bae21e13c4832aa2959771fe502e08