### PR TITLE
Handle zero theory scores and streamline dashboard stats

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -40,14 +40,28 @@ const Dashboard = () => {
   }
 
   const enrollments = getCohortEnrollments(selectedCohort.id);
-  
-  const stats = {
-    total: enrollments.length,
-    notStarted: enrollments.filter(e => e.status === 'NOT_STARTED').length,
-    theoryPass: enrollments.filter(e => e.status === 'THEORY_PASS').length,
-    certified: enrollments.filter(e => e.status === 'PRACTICAL_PASS').length,
-    nyc: enrollments.filter(e => e.status === 'NYC').length,
-  };
+
+  const stats = enrollments.reduce(
+    (acc, e) => {
+      acc.total += 1;
+      switch (e.status) {
+        case 'NOT_STARTED':
+          acc.notStarted += 1;
+          break;
+        case 'THEORY_PASS':
+          acc.theoryPass += 1;
+          break;
+        case 'PRACTICAL_PASS':
+          acc.certified += 1;
+          break;
+        case 'NYC':
+          acc.nyc += 1;
+          break;
+      }
+      return acc;
+    },
+    { total: 0, notStarted: 0, theoryPass: 0, certified: 0, nyc: 0 }
+  );
 
   const handleUploadRoster = () => {
     toast({
@@ -261,7 +275,7 @@ const Dashboard = () => {
                     </div>
                   </div>
                   <div className="flex items-center gap-3">
-                    {enrollment.theoryScore && (
+                    {enrollment.theoryScore !== undefined && (
                       <div className="text-sm">
                         Theory: <span className="font-medium">{enrollment.theoryScore}%</span>
                       </div>

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -4,8 +4,6 @@ import { vi } from 'vitest';
 
 import Dashboard from '@/pages/Dashboard';
 import { useAuth, type UserRole } from '@/lib/use-auth';
-import { type UserRole, useAuth } from '@/lib/auth';
-
 
 // Mock hooks and contexts used within Dashboard
 vi.mock('@/hooks/use-toast', () => ({
@@ -20,6 +18,25 @@ vi.mock('@/hooks/use-enterprise-branding', () => ({
 vi.mock('@/lib/use-auth', () => ({
   useAuth: vi.fn(),
 }));
+
+vi.mock('@/lib/mockData', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/mockData')>(
+    '@/lib/mockData'
+  );
+  return {
+    ...actual,
+    getCohortEnrollments: vi.fn(() => [
+      {
+        id: '1',
+        learnerId: '1',
+        cohortId: '1',
+        status: 'THEORY_PASS',
+        theoryScore: 0,
+        learner: actual.mockLearners[0],
+      },
+    ]),
+  };
+});
 
 const renderForRole = (role: UserRole) => {
   (useAuth as unknown as vi.Mock).mockReturnValue({
@@ -53,5 +70,14 @@ describe('Dashboard Quick Actions visibility', () => {
   it('hides quick actions for ASSESSOR', () => {
     renderForRole('ASSESSOR');
     expect(screen.queryByText('Create Cohort')).not.toBeInTheDocument();
+  });
+});
+
+describe('Learner theory score display', () => {
+  it('renders a 0% theory score', () => {
+    renderForRole('ADMIN');
+    expect(
+      screen.getByText((_, node) => node?.textContent === 'Theory: 0%')
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Compute enrollment status counts with a single `reduce`
- Render theory scores when the score is zero
- Add regression test to ensure 0% theory score is displayed

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bae223a9f0832a8828de877fdac738