### PR TITLE
feat: add courses table and seed

### DIFF
--- a/src/db/migrations/0000_create_courses.sql
+++ b/src/db/migrations/0000_create_courses.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS courses (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  code TEXT NOT NULL,
+  description TEXT,
+  version INTEGER NOT NULL DEFAULT 1,
+  status TEXT NOT NULL DEFAULT 'DRAFT',
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);
+

--- a/src/db/schema/courses.ts
+++ b/src/db/schema/courses.ts
@@ -1,0 +1,15 @@
+import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
+
+export const courses = sqliteTable('courses', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  title: text('title').notNull(),
+  code: text('code').notNull(),
+  description: text('description'),
+  version: integer('version').notNull().default(1),
+  status: text('status').notNull().default('DRAFT'),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .notNull()
+    .default(sql`(strftime('%s', 'now'))`),
+});
+

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,0 +1,15 @@
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { courses } from './schema/courses';
+
+const sqlite = new Database('sqlite.db');
+const db = drizzle(sqlite);
+
+await db.insert(courses).values({
+  title: 'Sample Course',
+  code: 'COURSE101',
+  description: 'A sample course for testing.',
+});
+
+console.log('Seed data inserted');
+


### PR DESCRIPTION
## Summary
- define `courses` table schema
- create migration for `courses` table
- seed sample course

## Testing
- `npm test`
- `npm run lint` *(fails: react-refresh/only-export-components, @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*
- `npx eslint src/db/schema/courses.ts src/db/seed.ts`


------
https://chatgpt.com/codex/tasks/task_e_68baebe17ea0832aa050c69e554ee05c