### PR TITLE
feat(db): add assessments table

### DIFF
--- a/drizzle/0000_assessments.sql
+++ b/drizzle/0000_assessments.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "assessments" (
+  "id" integer PRIMARY KEY AUTOINCREMENT,
+  "block_id" integer NOT NULL,
+  "num_questions" integer NOT NULL,
+  "pass_mark_percent" integer NOT NULL,
+  "time_limit_minutes" integer NOT NULL,
+  "shuffle" integer NOT NULL DEFAULT 0,
+  "max_attempts" integer,
+  "cooldown_minutes" integer,
+  CONSTRAINT "assessments_block_id_unique" UNIQUE("block_id")
+);

--- a/drizzle/0001_seed_assessments.sql
+++ b/drizzle/0001_seed_assessments.sql
@@ -1,0 +1,2 @@
+INSERT INTO assessments (block_id, num_questions, pass_mark_percent, time_limit_minutes, shuffle, max_attempts, cooldown_minutes)
+VALUES (1, 10, 70, 30, 1, 3, 60);

--- a/src/db/schema/assessments.ts
+++ b/src/db/schema/assessments.ts
@@ -1,0 +1,12 @@
+import { sqliteTable, integer } from "drizzle-orm/sqlite-core";
+
+export const assessments = sqliteTable("assessments", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  blockId: integer("block_id").notNull().unique(),
+  numQuestions: integer("num_questions").notNull(),
+  passMarkPercent: integer("pass_mark_percent").notNull(),
+  timeLimitMinutes: integer("time_limit_minutes").notNull(),
+  shuffle: integer("shuffle", { mode: "boolean" }).notNull().default(false),
+  maxAttempts: integer("max_attempts"),
+  cooldownMinutes: integer("cooldown_minutes"),
+});

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,0 +1,1 @@
+export * from "./assessments";


### PR DESCRIPTION
## Summary
- add `assessments` table schema with block-level uniqueness and attempt configuration
- create SQL migrations including seed example record

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baebe3a410832aab27c1fd48007865