### PR TITLE
Add questions schema, migration, and seed data

### DIFF
--- a/drizzle/0000_questions.sql
+++ b/drizzle/0000_questions.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `questions` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `assessment_id` integer NOT NULL,
+  `type` text NOT NULL,
+  `body` text NOT NULL,
+  `choices_json` text,
+  `correct_index` integer,
+  `correct_bool` integer,
+  `explanation` text,
+  `tags` text,
+  CHECK (`type` IN ('MCQ','TF')),
+  CHECK (`type` != 'MCQ' OR `choices_json` IS NOT NULL),
+  CHECK (`type` != 'MCQ' OR `correct_index` IS NOT NULL),
+  CHECK (`type` != 'TF' OR `correct_bool` IS NOT NULL)
+);

--- a/src/db/schema/questions.ts
+++ b/src/db/schema/questions.ts
@@ -1,0 +1,27 @@
+import { sqliteTable, integer, text } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+
+export const questionTypes = ["MCQ", "TF"] as const;
+
+export const questions = sqliteTable(
+  "questions",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    assessmentId: integer("assessment_id").notNull(),
+    type: text("type", { enum: questionTypes }).notNull(),
+    body: text("body").notNull(),
+    choicesJson: text("choices_json", { mode: "json" }).$type<string[] | null>(),
+    correctIndex: integer("correct_index"),
+    correctBool: integer("correct_bool", { mode: "boolean" }),
+    explanation: text("explanation"),
+    tags: text("tags"),
+  },
+  (t) => ({
+    mcqChoices: sql`CHECK (${t.type} != 'MCQ' OR ${t.choicesJson} IS NOT NULL)`,
+    mcqCorrectIndex: sql`CHECK (${t.type} != 'MCQ' OR ${t.correctIndex} IS NOT NULL)`,
+    tfCorrectBool: sql`CHECK (${t.type} != 'TF' OR ${t.correctBool} IS NOT NULL)`,
+  })
+);
+
+export type Question = typeof questions.$inferSelect;
+export type NewQuestion = typeof questions.$inferInsert;

--- a/src/db/seed/questions.ts
+++ b/src/db/seed/questions.ts
@@ -1,0 +1,47 @@
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { questions } from "../schema/questions";
+
+const sqlite = new Database("sqlite.db");
+const db = drizzle(sqlite);
+
+const seedQuestions = [
+  {
+    assessmentId: 1,
+    type: "MCQ",
+    body: "What is 2 + 2?",
+    choicesJson: ["3", "4", "5", "6"],
+    correctIndex: 1,
+    explanation: "2 + 2 equals 4.",
+    tags: "math,arithmetic",
+  },
+  {
+    assessmentId: 1,
+    type: "MCQ",
+    body: "What color is the sky on a clear day?",
+    choicesJson: ["Blue", "Green", "Red", "Yellow"],
+    correctIndex: 0,
+    explanation: "The sky appears blue due to the scattering of sunlight.",
+    tags: "science",
+  },
+  {
+    assessmentId: 2,
+    type: "TF",
+    body: "The Earth is flat.",
+    correctBool: false,
+    explanation: "The Earth is roughly spherical.",
+    tags: "geography",
+  },
+  {
+    assessmentId: 2,
+    type: "TF",
+    body: "JavaScript is a programming language.",
+    correctBool: true,
+    explanation: "JavaScript is used to build web applications.",
+    tags: "technology",
+  },
+];
+
+db.insert(questions).values(seedQuestions).run();
+
+console.log("Seeded questions");


### PR DESCRIPTION
## Summary
- define `questions` table schema with MCQ/TF constraints
- add migration creating `questions` table
- seed database with sample MCQ and TF questions

## Testing
- `npm test`
- `npm run lint` *(fails: 5 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68baebe437bc832ab31b5dc5b5a9f7fd