### PR TITLE
feat: add role-based auth guard

### DIFF
--- a/src/middleware/authGuard.ts
+++ b/src/middleware/authGuard.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from 'express';
+
+interface RequestWithUser extends Request {
+  user?: {
+    role?: string;
+    [key: string]: unknown;
+  };
+}
+
+export function requireRole(...allowedRoles: string[]) {
+  return (req: RequestWithUser, res: Response, next: NextFunction) => {
+    const userRole = req.user?.role;
+    if (!userRole || !allowedRoles.includes(userRole)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    next();
+  };
+}


### PR DESCRIPTION
## Summary
- export requireRole middleware to restrict access based on user roles

## Testing
- `npm run lint` *(fails: interface declaring no members, no-explicit-any, forbidden require import)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68baec1666b4832a9dd52bc5d68e0075