### PR TITLE
feat: add course creation endpoint

### DIFF
--- a/src/api/courses/createCourse.ts
+++ b/src/api/courses/createCourse.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from "express";
+import { db } from "../db";
+import { courses } from "../schema";
+
+interface CourseInput {
+  title: string;
+  code?: string;
+  description?: string;
+}
+
+export async function createCourse(req: Request, res: Response) {
+  const { title, code, description } = req.body as CourseInput;
+
+  if (!title) {
+    res.status(400).json({ error: "Title is required" });
+    return;
+  }
+
+  const [course] = await db
+    .insert(courses)
+    .values({
+      title,
+      code: code ?? null,
+      description: description ?? null,
+      status: "DRAFT",
+    })
+    .returning();
+
+  res.json(course);
+}

--- a/src/api/db.ts
+++ b/src/api/db.ts
@@ -1,0 +1,5 @@
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+
+const sqlite = new Database("sqlite.db");
+export const db = drizzle(sqlite);

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -1,0 +1,9 @@
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const courses = sqliteTable("courses", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  title: text("title").notNull(),
+  code: text("code"),
+  description: text("description"),
+  status: text("status").notNull(),
+});


### PR DESCRIPTION
## Summary
- add SQLite/Drizzle database config and schema
- implement course creation controller inserting DRAFT status

## Testing
- `npm test -- --run` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68baec174108832a9c3567e04e9e8245