### PR TITLE
feat: add course list filtering

### DIFF
--- a/src/api/courses/listCourses.ts
+++ b/src/api/courses/listCourses.ts
@@ -1,0 +1,32 @@
+import { db } from "../db";
+import { courses } from "../db/schema";
+import { and, desc, eq, like, or } from "drizzle-orm";
+
+export interface ListCoursesParams {
+  q?: string;
+  status?: string;
+}
+
+export const listCourses = async ({ q, status }: ListCoursesParams = {}) => {
+  const conditions = [] as any[];
+
+  if (q) {
+    const term = `%${q}%`;
+    conditions.push(
+      or(like(courses.title, term), like(courses.code, term))
+    );
+  }
+
+  if (status) {
+    conditions.push(eq(courses.status, status));
+  }
+
+  let query = db.select().from(courses);
+  if (conditions.length === 1) {
+    query = query.where(conditions[0]);
+  } else if (conditions.length > 1) {
+    query = query.where(and(...conditions));
+  }
+
+  return query.orderBy(desc(courses.createdAt)).all();
+};


### PR DESCRIPTION
## Summary
- support listing courses with search and status filters
- sort results by newest creation date

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baec17abac832a88a1ed06059fe861