### PR TITLE
feat: add block reorder endpoint

### DIFF
--- a/api/db.ts
+++ b/api/db.ts
@@ -1,0 +1,6 @@
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import * as schema from './schema';
+
+const sqlite = new Database('sqlite.db');
+export const db = drizzle(sqlite, { schema });

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import { reorderBlocksRouter } from './routes/reorderBlocks';
+
+const app = express();
+app.use(express.json());
+app.use('/blocks/reorder', reorderBlocksRouter);
+
+export default app;
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = Number(process.env.PORT) || 3000;
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}

--- a/api/routes/reorderBlocks.ts
+++ b/api/routes/reorderBlocks.ts
@@ -1,0 +1,47 @@
+import { Router } from 'express';
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { blocks } from '../schema';
+
+export const reorderBlocksRouter = Router();
+
+reorderBlocksRouter.post('/', (req, res) => {
+  const { courseId, order } = req.body as { courseId: number; order: number[] };
+
+  if (
+    typeof courseId !== 'number' ||
+    !Array.isArray(order) ||
+    order.some((id) => typeof id !== 'number')
+  ) {
+    return res.status(400).json({ error: 'Invalid payload' });
+  }
+
+  const existing = db
+    .select({ id: blocks.id })
+    .from(blocks)
+    .where(eq(blocks.courseId, courseId))
+    .all();
+
+  const existingIds = existing.map((b) => b.id);
+  const orderSet = new Set(order);
+
+  if (
+    existingIds.length !== order.length ||
+    existingIds.some((id) => !orderSet.has(id))
+  ) {
+    return res
+      .status(400)
+      .json({ error: 'Order does not match existing blocks' });
+  }
+
+  db.transaction((tx) => {
+    order.forEach((blockId, index) => {
+      tx.update(blocks)
+        .set({ position: index })
+        .where(eq(blocks.id, blockId))
+        .run();
+    });
+  });
+
+  return res.json({ success: true });
+});

--- a/api/schema.ts
+++ b/api/schema.ts
@@ -1,0 +1,7 @@
+import { sqliteTable, integer } from 'drizzle-orm/sqlite-core';
+
+export const blocks = sqliteTable('blocks', {
+  id: integer('id').primaryKey(),
+  courseId: integer('course_id').notNull(),
+  position: integer('position').notNull(),
+});

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2023"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist-api"
+  },
+  "include": ["api/**/*"]
+}


### PR DESCRIPTION
## Summary
- add Express endpoint to reorder course blocks
- update block positions in a transaction with validation
- configure API build via tsconfig

## Testing
- `npx vitest run` (fails: No test files found)
- `npm run lint` (fails: 5 errors, 9 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68baec202a38832a920cfb66f241ece0