### PR TITLE
feat: support deleting blocks and reorder

### DIFF
--- a/src/lib/blocks.test.ts
+++ b/src/lib/blocks.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { deleteBlock, reorderBlocks, Block } from "./blocks";
+
+const makeBlocks = (): Block[] => [
+  {
+    id: "b1",
+    order: 1,
+    type: "content_unit",
+    contentUnits: [
+      { id: "cu1" },
+      { id: "cu2" },
+    ],
+  },
+  {
+    id: "b2",
+    order: 2,
+    type: "assessment",
+    assessment: {
+      id: "a1",
+      questions: [
+        { id: "q1" },
+        { id: "q2" },
+      ],
+    },
+  },
+  {
+    id: "b3",
+    order: 3,
+    type: "content_unit",
+    contentUnits: [],
+  },
+];
+
+describe("deleteBlock", () => {
+  it("hard deletes a block and reorders remaining blocks", () => {
+    const result = deleteBlock(makeBlocks(), "b2", { hard: true });
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("b1");
+    expect(result[0].order).toBe(1);
+    expect(result[1].id).toBe("b3");
+    expect(result[1].order).toBe(2);
+  });
+
+  it("soft deletes a content unit block and reorders others", () => {
+    const result = deleteBlock(makeBlocks(), "b1");
+    expect(result).toHaveLength(3);
+    const deleted = result.find((b) => b.id === "b1");
+    expect(deleted?.deleted).toBe(true);
+    expect(deleted?.order).toBe(0);
+    if (deleted && deleted.type === "content_unit") {
+      expect(deleted.contentUnits.every((cu) => cu.deleted)).toBe(true);
+    }
+    const remaining = result.filter((b) => !b.deleted);
+    expect(remaining.map((b) => b.order)).toEqual([1, 2]);
+  });
+
+  it("soft deletes an assessment block including its questions", () => {
+    const result = deleteBlock(makeBlocks(), "b2");
+    const deleted = result.find((b) => b.id === "b2");
+    expect(deleted?.deleted).toBe(true);
+    if (deleted && deleted.type === "assessment") {
+      expect(deleted.assessment.deleted).toBe(true);
+      expect(deleted.assessment.questions.every((q) => q.deleted)).toBe(true);
+    }
+  });
+});
+
+// Ensure reorderBlocks works independently
+it("reorders blocks sequentially", () => {
+  const blocks = makeBlocks();
+  blocks[1].deleted = true;
+  const reordered = reorderBlocks(blocks);
+  expect(reordered.find((b) => b.id === "b2")?.order).toBe(0);
+  expect(reordered.filter((b) => !b.deleted).map((b) => b.order)).toEqual([1, 2]);
+});

--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -1,0 +1,99 @@
+export interface Question {
+  id: string;
+  body?: string;
+  choices?: string[];
+  correctIndex?: number;
+  tags?: string[];
+  deleted?: boolean;
+}
+
+export interface ContentUnit {
+  id: string;
+  deleted?: boolean;
+}
+
+export interface Assessment {
+  id: string;
+  questions: Question[];
+  deleted?: boolean;
+}
+
+export type Block =
+  | {
+      id: string;
+      order: number;
+      type: "content_unit";
+      contentUnits: ContentUnit[];
+      deleted?: boolean;
+    }
+  | {
+      id: string;
+      order: number;
+      type: "assessment";
+      assessment: Assessment;
+      deleted?: boolean;
+    };
+
+export interface DeleteOptions {
+  hard?: boolean;
+}
+
+/**
+ * Remove a block by id. When soft deleting, the block and any nested items are
+ * marked as deleted. When hard deleting, the block is removed entirely. After
+ * removal, remaining blocks are reordered sequentially.
+ */
+export function deleteBlock(
+  blocks: Block[],
+  blockId: string,
+  options: DeleteOptions = {}
+): Block[] {
+  const { hard = false } = options;
+
+  if (hard) {
+    const remaining = blocks.filter((b) => b.id !== blockId);
+    return reorderBlocks(remaining);
+  }
+
+  const updated = blocks.map((block) => {
+    if (block.id !== blockId) return block;
+    if (block.type === "content_unit") {
+      return {
+        ...block,
+        deleted: true,
+        contentUnits: block.contentUnits.map((cu) => ({ ...cu, deleted: true })),
+      } as Block;
+    }
+    if (block.type === "assessment") {
+      return {
+        ...block,
+        deleted: true,
+        assessment: {
+          ...block.assessment,
+          deleted: true,
+          questions: block.assessment.questions.map((q) => ({
+            ...q,
+            deleted: true,
+          })),
+        },
+      } as Block;
+    }
+    return { ...block, deleted: true } as Block;
+  });
+
+  return reorderBlocks(updated);
+}
+
+/**
+ * Reorder blocks sequentially, skipping any that have been soft deleted. Deleted
+ * blocks receive an order of 0.
+ */
+export function reorderBlocks(blocks: Block[]): Block[] {
+  let order = 1;
+  return blocks.map((block) => {
+    if (block.deleted) {
+      return { ...block, order: 0 };
+    }
+    return { ...block, order: order++ };
+  });
+}


### PR DESCRIPTION
## Summary
- add block utilities to soft/hard delete associated content units or assessments and their questions
- ensure remaining blocks are re-ordered sequentially
- cover block removal and reordering logic with vitest tests

## Testing
- `npm test`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, A require() style import is forbidden)*
- `npx eslint src/lib/blocks.ts src/lib/blocks.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68baec20cc70832a9dc17ae966913ee0