### PR TITLE
feat: conditionally update fields and replace pdf

### DIFF
--- a/src/lib/fileUtils.test.ts
+++ b/src/lib/fileUtils.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { applyConditionalUpdate, replacePdf } from './fileUtils';
+
+describe('applyConditionalUpdate', () => {
+  it('updates only pdf field when content_type is application/pdf', () => {
+    const original = { title: 'Old', pdf: 'old.pdf', description: 'Old desc' };
+    const result = applyConditionalUpdate(original, {
+      content_type: 'application/pdf',
+      pdf: 'new.pdf',
+      title: 'New',
+    });
+    expect(result).toEqual({ title: 'Old', pdf: 'new.pdf', description: 'Old desc' });
+  });
+
+  it('updates non-pdf fields when content_type is not pdf', () => {
+    const original = { title: 'Old', pdf: 'old.pdf', description: 'Old desc' };
+    const result = applyConditionalUpdate(original, {
+      content_type: 'application/json',
+      title: 'New',
+      description: 'New desc',
+      pdf: 'ignored.pdf',
+    });
+    expect(result).toEqual({ title: 'New', pdf: 'old.pdf', description: 'New desc' });
+  });
+});
+
+describe('replacePdf', () => {
+  it('deletes old file when replacing', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pdf-'));
+    const oldPath = path.join(dir, 'old.pdf');
+    await fs.writeFile(oldPath, 'old');
+
+    const newBuffer = Buffer.from('new');
+    const filename = await replacePdf('old.pdf', newBuffer, dir);
+    const newPath = path.join(dir, filename);
+
+    const data = await fs.readFile(newPath, 'utf8');
+    expect(data).toBe('new');
+
+    let oldExists = true;
+    try {
+      await fs.access(oldPath);
+    } catch {
+      oldExists = false;
+    }
+    expect(oldExists).toBe(false);
+  });
+});

--- a/src/lib/fileUtils.ts
+++ b/src/lib/fileUtils.ts
@@ -1,0 +1,61 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export interface UpdatePayload {
+  content_type?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Apply updates to an object while respecting the provided content_type.
+ * - When content_type is "application/pdf" only the `pdf` field can be updated.
+ * - For any other content_type all fields except `pdf` are updated.
+ */
+export function applyConditionalUpdate<T extends Record<string, unknown>>(original: T, payload: UpdatePayload): T {
+  const { content_type, ...rest } = payload;
+  const updated: Record<string, unknown> = { ...original };
+
+  if (!content_type) {
+    Object.assign(updated, rest);
+    return updated as T;
+  }
+
+  if (content_type === 'application/pdf') {
+    if (Object.prototype.hasOwnProperty.call(rest, 'pdf')) {
+      updated['pdf'] = rest['pdf'];
+    }
+    return updated as T;
+  }
+
+  // For non-pdf content types, ignore attempts to update the `pdf` field
+  for (const [key, value] of Object.entries(rest)) {
+    if (key === 'pdf') continue;
+    updated[key] = value;
+  }
+  return updated as T;
+}
+
+/**
+ * Replace an existing PDF file with a new one. When an old file path is
+ * provided, it will be removed before the new file is written.
+ *
+ * @param oldPath  Relative path of the existing file inside `uploadDir`.
+ * @param newFile  Buffer containing the new PDF data.
+ * @param uploadDir Directory where PDF files are stored.
+ * @returns The filename of the newly written PDF.
+ */
+export async function replacePdf(oldPath: string | undefined, newFile: Buffer, uploadDir: string): Promise<string> {
+  await fs.mkdir(uploadDir, { recursive: true });
+
+  if (oldPath) {
+    try {
+      await fs.unlink(path.join(uploadDir, oldPath));
+    } catch {
+      // File may not exist; ignore errors
+    }
+  }
+
+  const filename = `file-${Date.now()}.pdf`;
+  await fs.writeFile(path.join(uploadDir, filename), newFile);
+  return filename;
+}


### PR DESCRIPTION
## Summary
- add helper to update fields based on provided content type
- delete old pdf when a new one is uploaded
- test conditional updates and pdf replacement

## Testing
- `npx vitest run`
- `npm run lint` *(fails: A `require()` style import is forbidden, Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68baec21a810832ab5159637e2242a3c