### PR TITLE
feat: add paginated question retrieval

### DIFF
--- a/src/lib/questions.test.ts
+++ b/src/lib/questions.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { getAssessmentQuestions } from './questions';
+
+describe('getAssessmentQuestions', () => {
+  it('paginates results', () => {
+    const result = getAssessmentQuestions({ page: 1, pageSize: 5 });
+    expect(result.data).toHaveLength(5);
+    expect(result.total).toBeGreaterThan(5);
+  });
+
+  it('filters by tag', () => {
+    const result = getAssessmentQuestions({ tags: ['cpr'] });
+    expect(result.total).toBe(3);
+    // ensure all returned questions include the tag
+    expect(result.data.every((q) => q.tags.includes('cpr'))).toBe(true);
+  });
+
+  it('filters by search term', () => {
+    const result = getAssessmentQuestions({ search: 'tourniquet' });
+    expect(result.total).toBe(3);
+    expect(result.data.every((q) =>
+      q.body.toLowerCase().includes('tourniquet') ||
+      q.choices.some((c) => c.toLowerCase().includes('tourniquet'))
+    )).toBe(true);
+  });
+});

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -1,0 +1,51 @@
+import { mockQuestions, type Question } from './mockData';
+
+export interface QuestionQuery {
+  page?: number;
+  pageSize?: number;
+  tags?: string[];
+  search?: string;
+}
+
+export interface QuestionPage {
+  data: Question[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+/**
+ * Returns a paginated list of questions filtered by tags or search term.
+ */
+export function getAssessmentQuestions({
+  page = 1,
+  pageSize = 10,
+  tags = [],
+  search = '',
+}: QuestionQuery = {}): QuestionPage {
+  let filtered = mockQuestions;
+
+  if (tags.length) {
+    filtered = filtered.filter((q) => tags.every((t) => q.tags.includes(t)));
+  }
+
+  if (search) {
+    const term = search.toLowerCase();
+    filtered = filtered.filter(
+      (q) =>
+        q.body.toLowerCase().includes(term) ||
+        q.choices.some((choice) => choice.toLowerCase().includes(term))
+    );
+  }
+
+  const total = filtered.length;
+  const start = (page - 1) * pageSize;
+  const data = filtered.slice(start, start + pageSize);
+
+  return {
+    data,
+    total,
+    page,
+    pageSize,
+  };
+}


### PR DESCRIPTION
## Summary
- add `getAssessmentQuestions` utility to paginate and filter question bank
- test pagination, tag filtering and search functionality

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68baec26274c832abeadf1fa5f6bb14d