### PR TITLE
feat: add question form modal

### DIFF
--- a/src/components/QuestionFormDialog.tsx
+++ b/src/components/QuestionFormDialog.tsx
@@ -1,0 +1,212 @@
+import { useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { Question } from '@/lib/mockData';
+
+const schema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('MCQ'),
+    body: z.string().min(1, 'Question is required'),
+    choices: z.array(z.string().min(1, 'Choice is required')).min(2, 'At least two choices'),
+    correctIndex: z.number().int().refine((val, ctx) => val >= 0 && val < ctx.parent.choices.length, {
+      message: 'Select a valid correct answer'
+    })
+  }),
+  z.object({
+    type: z.literal('TF'),
+    body: z.string().min(1, 'Question is required'),
+    correctIndex: z.number().int().min(0).max(1)
+  })
+]);
+
+type QuestionFormValues = z.infer<typeof schema>;
+
+const defaultValues: QuestionFormValues = {
+  type: 'MCQ',
+  body: '',
+  choices: ['', ''],
+  correctIndex: 0
+};
+
+interface QuestionFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  question?: Question;
+}
+
+export function QuestionFormDialog({ open, onOpenChange, question }: QuestionFormDialogProps) {
+  const form = useForm<QuestionFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: question ? { ...question } : defaultValues
+  });
+
+  const type = form.watch('type');
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: 'choices' as const });
+
+  useEffect(() => {
+    if (type === 'TF') {
+      form.setValue('choices', ['True', 'False']);
+      if (form.getValues('correctIndex') > 1) {
+        form.setValue('correctIndex', 0);
+      }
+    } else if (type === 'MCQ' && form.getValues('choices').length < 2) {
+      form.setValue('choices', ['', '']);
+    }
+  }, [type, form]);
+
+  const handleSubmit = async (values: QuestionFormValues, addAnother = false) => {
+    const payload = values.type === 'TF' ? { ...values, choices: ['True', 'False'] } : values;
+    const url = question ? `/api/questions/${question.id}` : '/api/questions';
+    const method = question ? 'PATCH' : 'POST';
+    await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (addAnother) {
+      form.reset(defaultValues);
+    } else {
+      onOpenChange(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{question ? 'Edit Question' : 'Add Question'}</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit((data) => handleSubmit(data, false))} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Type</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="MCQ">Multiple Choice</SelectItem>
+                      <SelectItem value="TF">True / False</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="body"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Question</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {type === 'MCQ' && (
+              <div className="space-y-2">
+                {fields.map((field, index) => (
+                  <FormField
+                    key={field.id}
+                    control={form.control}
+                    name={`choices.${index}` as const}
+                    render={({ field }) => (
+                      <FormItem className="flex items-center gap-2">
+                        <FormControl>
+                          <Input {...field} placeholder={`Choice ${index + 1}`} />
+                        </FormControl>
+                        {fields.length > 2 && (
+                          <Button type="button" variant="outline" onClick={() => remove(index)}>
+                            Remove
+                          </Button>
+                        )}
+                      </FormItem>
+                    )}
+                  />
+                ))}
+                <Button type="button" variant="secondary" onClick={() => append('')}>
+                  Add Choice
+                </Button>
+                <FormField
+                  control={form.control}
+                  name="correctIndex"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Correct Answer</FormLabel>
+                      <Select onValueChange={(v) => field.onChange(Number(v))} value={String(field.value)}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select correct choice" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {fields.map((_, idx) => (
+                            <SelectItem key={idx} value={String(idx)}>
+                              Choice {idx + 1}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            )}
+
+            {type === 'TF' && (
+              <FormField
+                control={form.control}
+                name="correctIndex"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Correct Answer</FormLabel>
+                    <RadioGroup onValueChange={(v) => field.onChange(Number(v))} value={String(field.value)}>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="0" id="true" />
+                        <Label htmlFor="true">True</Label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="1" id="false" />
+                        <Label htmlFor="false">False</Label>
+                      </div>
+                    </RadioGroup>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <DialogFooter className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={form.handleSubmit((data) => handleSubmit(data, true))}
+              >
+                Save & Add Another
+              </Button>
+              <Button type="submit">Save</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -6,6 +6,7 @@ export interface Question {
   choices: string[];
   correctIndex: number;
   tags: string[];
+  type: 'MCQ' | 'TF';
 }
 
 export interface Learner {
@@ -74,70 +75,80 @@ export const mockQuestions: Question[] = [
     body: 'What is the correct compression depth for adult CPR?',
     choices: ['At least 2 inches (5 cm)', 'At least 1 inch (2.5 cm)', 'At least 3 inches (7.5 cm)', 'At least 1.5 inches (4 cm)'],
     correctIndex: 0,
-    tags: ['cpr', 'basic_life_support']
+    tags: ['cpr', 'basic_life_support'],
+    type: 'MCQ'
   },
   {
     id: '2',
     body: 'What is the correct compression rate for CPR?',
     choices: ['60-80 per minute', '80-100 per minute', '100-120 per minute', '120-140 per minute'],
     correctIndex: 2,
-    tags: ['cpr', 'basic_life_support']
+    tags: ['cpr', 'basic_life_support'],
+    type: 'MCQ'
   },
   {
     id: '3',
     body: 'When should you use an AED?',
     choices: ['On any unconscious person', 'Only when trained personnel arrive', 'On unresponsive victims with no normal breathing', 'After 10 minutes of CPR'],
     correctIndex: 2,
-    tags: ['aed', 'basic_life_support']
+    tags: ['aed', 'basic_life_support'],
+    type: 'MCQ'
   },
   {
     id: '4',
     body: 'How long should you flush eyes exposed to chemicals?',
     choices: ['5 minutes', '10 minutes', '15 minutes', '20 minutes'],
     correctIndex: 2,
-    tags: ['chemical_exposure', 'eye_injury']
+    tags: ['chemical_exposure', 'eye_injury'],
+    type: 'MCQ'
   },
   {
     id: '5',
     body: 'What does the acronym SBAR stand for in medical handover?',
     choices: ['Situation, Background, Assessment, Recommendation', 'Safety, Background, Action, Result', 'Situation, Baseline, Action, Response', 'Safety, Baseline, Assessment, Recommendation'],
     correctIndex: 0,
-    tags: ['communication', 'handover']
+    tags: ['communication', 'handover'],
+    type: 'MCQ'
   },
   {
     id: '6',
     body: 'What is the first step in controlling severe bleeding?',
     choices: ['Apply a tourniquet', 'Direct pressure on the wound', 'Elevate the limb', 'Apply pressure to pressure points'],
     correctIndex: 1,
-    tags: ['bleeding_control', 'wound_care']
+    tags: ['bleeding_control', 'wound_care'],
+    type: 'MCQ'
   },
   {
     id: '7',
     body: 'How often should you switch rescuers during CPR?',
     choices: ['Every minute', 'Every 2 minutes', 'Every 5 minutes', 'When tired'],
     correctIndex: 1,
-    tags: ['cpr', 'basic_life_support']
+    tags: ['cpr', 'basic_life_support'],
+    type: 'MCQ'
   },
   {
     id: '8',
     body: 'What is the universal sign of choking?',
     choices: ['Pointing to throat', 'Hands clutching throat', 'Waving hands', 'Pointing to chest'],
     correctIndex: 1,
-    tags: ['choking', 'airway_obstruction']
+    tags: ['choking', 'airway_obstruction'],
+    type: 'MCQ'
   },
   {
     id: '9',
     body: 'When applying a tourniquet, how tight should it be?',
     choices: ['Snug but comfortable', 'Tight enough to stop arterial bleeding', 'As tight as possible', 'Just tight enough to slow bleeding'],
     correctIndex: 1,
-    tags: ['bleeding_control', 'tourniquet']
+    tags: ['bleeding_control', 'tourniquet'],
+    type: 'MCQ'
   },
   {
     id: '10',
     body: 'What information should be included on a tourniquet time tag?',
     choices: ['Patient name only', 'Time applied only', 'Time applied and location', 'Time applied, location, and applied by'],
     correctIndex: 3,
-    tags: ['bleeding_control', 'documentation']
+    tags: ['bleeding_control', 'documentation'],
+    type: 'MCQ'
   }
 ];
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,24 +5,27 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { StatusBadge } from '@/components/StatusBadge';
-import { 
-  Users, 
-  Calendar, 
-  Upload, 
-  Download, 
-  FileText, 
+import {
+  Users,
+  Calendar,
+  Upload,
+  Download,
+  FileText,
   Shield,
   LogOut,
   Plus,
-  BarChart3
+  BarChart3,
+  FilePlus
 } from 'lucide-react';
 import { mockCohorts, getCohortEnrollments } from '@/lib/mockData';
 import { useToast } from '@/hooks/use-toast';
+import { QuestionFormDialog } from '@/components/QuestionFormDialog';
 
 const Dashboard = () => {
   const { user, logout } = useAuth();
   const { toast } = useToast();
   const [selectedCohort] = useState(mockCohorts[0]);
+  const [questionDialogOpen, setQuestionDialogOpen] = useState(false);
 
   if (!user) {
     return <Navigate to="/login" replace />;
@@ -91,7 +94,7 @@ const Dashboard = () => {
       <div className="container mx-auto px-4 py-8 space-y-8">
         {/* Quick Actions */}
         {user.role === 'ADMIN' && (
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
             <Card className="border-primary/20 hover:shadow-lg transition-shadow cursor-pointer" onClick={handleCreateCohort}>
               <CardContent className="p-6 text-center">
                 <Plus className="h-8 w-8 text-primary mx-auto mb-2" />
@@ -121,6 +124,17 @@ const Dashboard = () => {
                 <FileText className="h-8 w-8 text-accent mx-auto mb-2" />
                 <h3 className="font-semibold">Certificate Register</h3>
                 <p className="text-sm text-muted-foreground">Manage issued certificates</p>
+              </CardContent>
+            </Card>
+
+            <Card
+              className="border-secondary/20 hover:shadow-lg transition-shadow cursor-pointer"
+              onClick={() => setQuestionDialogOpen(true)}
+            >
+              <CardContent className="p-6 text-center">
+                <FilePlus className="h-8 w-8 text-secondary mx-auto mb-2" />
+                <h3 className="font-semibold">Add Question</h3>
+                <p className="text-sm text-muted-foreground">Create new quiz item</p>
               </CardContent>
             </Card>
           </div>
@@ -227,6 +241,7 @@ const Dashboard = () => {
           </CardContent>
         </Card>
       </div>
+      <QuestionFormDialog open={questionDialogOpen} onOpenChange={setQuestionDialogOpen} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add QuestionFormDialog for MCQ and True/False questions with client validation
- integrate question modal into dashboard quick actions and support Save & Add Another
- annotate mock question data with question type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baec3a2ed0832abe06c33fc2cfaf90