### PR TITLE
Add builder validation side panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,13 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider, useAuth } from "@/lib/auth";
-import Index from "./pages/Index";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import Kiosk from "./pages/Kiosk";
 import Assessor from "./pages/Assessor";
 import Verify from "./pages/Verify";
 import NotFound from "./pages/NotFound";
+import Builder from "./pages/Builder";
 
 const queryClient = new QueryClient();
 
@@ -50,6 +50,7 @@ const App = () => (
             <Route path="/kiosk/:cohortId" element={<Kiosk />} />
             <Route path="/assessor/:cohortId" element={<Assessor />} />
             <Route path="/verify/:certificateCode" element={<Verify />} />
+            <Route path="/builder" element={<Builder />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/pages/Builder.tsx
+++ b/src/pages/Builder.tsx
@@ -1,0 +1,126 @@
+import { useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useToast } from '@/hooks/use-toast';
+
+interface Question {
+  id: number;
+  text: string;
+  choices: string[];
+}
+
+interface Issue {
+  questionId: number;
+  message: string;
+}
+
+const Builder = () => {
+  const [questions, setQuestions] = useState<Question[]>([
+    { id: 1, text: '', choices: ['', ''] },
+    { id: 2, text: '', choices: ['', ''] },
+  ]);
+
+  const questionRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [issues, setIssues] = useState<Issue[]>([]);
+  const [open, setOpen] = useState(false);
+  const { toast } = useToast();
+
+  const handleQuestionChange = (index: number, value: string) => {
+    setQuestions(prev => {
+      const updated = [...prev];
+      updated[index].text = value;
+      return updated;
+    });
+  };
+
+  const handleChoiceChange = (qIndex: number, cIndex: number, value: string) => {
+    setQuestions(prev => {
+      const updated = [...prev];
+      updated[qIndex].choices[cIndex] = value;
+      return updated;
+    });
+  };
+
+  const validate = () => {
+    const found: Issue[] = [];
+    questions.forEach(q => {
+      if (!q.text.trim()) {
+        found.push({ questionId: q.id, message: 'Question text is required' });
+      }
+      q.choices.forEach((c, idx) => {
+        if (!c.trim()) {
+          found.push({ questionId: q.id, message: `Choice ${idx + 1} is empty` });
+        }
+      });
+    });
+    setIssues(found);
+    setOpen(found.length > 0);
+    if (found.length === 0) {
+      toast({ title: 'Published successfully' });
+    }
+  };
+
+  const scrollToQuestion = (id: number) => {
+    const index = questions.findIndex(q => q.id === id);
+    const el = questionRefs.current[index];
+    el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      {questions.map((q, qi) => (
+        <div
+          key={q.id}
+          ref={el => (questionRefs.current[qi] = el)}
+          className="space-y-2 border p-4 rounded-md"
+        >
+          <Label htmlFor={`question-${q.id}`}>Question {qi + 1}</Label>
+          <Input
+            id={`question-${q.id}`}
+            value={q.text}
+            onChange={e => handleQuestionChange(qi, e.target.value)}
+            placeholder="Enter question text"
+          />
+          {q.choices.map((choice, ci) => (
+            <Input
+              key={ci}
+              value={choice}
+              onChange={e => handleChoiceChange(qi, ci, e.target.value)}
+              placeholder={`Choice ${ci + 1}`}
+            />
+          ))}
+        </div>
+      ))}
+
+      <Button onClick={validate}>Publish</Button>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent side="right">
+          <SheetHeader>
+            <SheetTitle>Publish Issues</SheetTitle>
+          </SheetHeader>
+          <ScrollArea className="mt-4 h-full">
+            <ul className="space-y-2">
+              {issues.map((issue, idx) => (
+                <li key={idx}>
+                  <button
+                    className="text-left text-destructive underline"
+                    onClick={() => scrollToQuestion(issue.questionId)}
+                  >
+                    Q{issue.questionId}: {issue.message}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </ScrollArea>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+};
+
+export default Builder;
+


### PR DESCRIPTION
## Summary
- add builder page with questions and publish workflow
- display side sheet with validation issues linking to blocks
- register builder route in app router

## Testing
- `npm run lint` *(fails: existing lint errors)*
- `npm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68baec3f4e84832aa71bce6fcef2f41d