### PR TITLE
Add course publishing with validation handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,11 +4,11 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider, useAuth } from "@/lib/auth";
-import Index from "./pages/Index";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import Kiosk from "./pages/Kiosk";
 import Assessor from "./pages/Assessor";
+import Course from "./pages/Course";
 import Verify from "./pages/Verify";
 import NotFound from "./pages/NotFound";
 
@@ -50,6 +50,7 @@ const App = () => (
             <Route path="/kiosk/:cohortId" element={<Kiosk />} />
             <Route path="/assessor/:cohortId" element={<Assessor />} />
             <Route path="/verify/:certificateCode" element={<Verify />} />
+            <Route path="/courses/:id" element={<Course />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/ValidationPanel.tsx
+++ b/src/components/ValidationPanel.tsx
@@ -1,0 +1,27 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+interface ValidationPanelProps {
+  errors: string[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const ValidationPanel: React.FC<ValidationPanelProps> = ({ errors, open, onOpenChange }) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Validation Errors</DialogTitle>
+      </DialogHeader>
+      <ul className="list-disc space-y-1 pl-4">
+        {errors.map((error, index) => (
+          <li key={index} className="text-sm text-destructive">
+            {error}
+          </li>
+        ))}
+      </ul>
+    </DialogContent>
+  </Dialog>
+);
+
+export default ValidationPanel;
+

--- a/src/pages/Course.tsx
+++ b/src/pages/Course.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import ValidationPanel from "@/components/ValidationPanel";
+
+interface Course {
+  id: string;
+  status: string;
+  version: number;
+}
+
+const CoursePage = () => {
+  const { id } = useParams();
+  const { toast } = useToast();
+  const [course, setCourse] = useState<Course>({
+    id: id || "1",
+    status: "DRAFT",
+    version: 1,
+  });
+  const [errors, setErrors] = useState<string[]>([]);
+  const [open, setOpen] = useState(false);
+
+  const handlePublish = async () => {
+    try {
+      const res = await fetch(`/api/courses/${course.id}/publish`, { method: "POST" });
+      if (res.ok) {
+        setCourse((prev) => ({ ...prev, status: "PUBLISHED", version: prev.version + 1 }));
+        toast({ title: "Course published" });
+      } else {
+        const data = await res.json().catch(() => ({}));
+        const rawErrors = (data.errors ?? []) as Array<{ message?: string } | string>;
+        const parsed = rawErrors.map((e) =>
+          typeof e === "string" ? e : e.message ?? JSON.stringify(e)
+        );
+        setErrors(parsed.length ? parsed : ["Unable to publish course."]);
+        setOpen(true);
+      }
+    } catch {
+      setErrors(["Network error"]);
+      setOpen(true);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <div>
+        <p>Status: {course.status}</p>
+        <p>Version: {course.version}</p>
+      </div>
+      <Button onClick={handlePublish}>Publish</Button>
+      <ValidationPanel errors={errors} open={open} onOpenChange={setOpen} />
+    </div>
+  );
+};
+
+export default CoursePage;
+


### PR DESCRIPTION
## Summary
- add ValidationPanel component for displaying validation errors
- add Course page with publish action that calls `/api/courses/:id/publish`
- wire Course route into app router

## Testing
- `npm test -- --run` *(fails: No test files found)*
- `npm run lint` *(fails: existing lint errors in unrelated files)*


------
https://chatgpt.com/codex/tasks/task_e_68baec40a328832a8205c28dc79d8fef