### PR TITLE
feat: add course preview simulation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import Kiosk from "./pages/Kiosk";
 import Assessor from "./pages/Assessor";
+import CoursePreview from "./pages/CoursePreview";
 import Verify from "./pages/Verify";
 import NotFound from "./pages/NotFound";
 
@@ -50,6 +51,14 @@ const App = () => (
             <Route path="/kiosk/:cohortId" element={<Kiosk />} />
             <Route path="/assessor/:cohortId" element={<Assessor />} />
             <Route path="/verify/:certificateCode" element={<Verify />} />
+            <Route
+              path="/admin/courses/:courseId/preview"
+              element={
+                <ProtectedRoute>
+                  <CoursePreview />
+                </ProtectedRoute>
+              }
+            />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Assessor.tsx
+++ b/src/pages/Assessor.tsx
@@ -17,13 +17,16 @@ import {
   FileCheck,
   ArrowLeft
 } from 'lucide-react';
-import { getCohortEnrollments, type PracticalRubric } from '@/lib/mockData';
+import { getCohortEnrollments, type PracticalRubric, type Enrollment, type Learner } from '@/lib/mockData';
 import { useToast } from '@/hooks/use-toast';
 
 const Assessor = () => {
   const { cohortId } = useParams();
   const { toast } = useToast();
-  const [selectedLearner, setSelectedLearner] = useState<any>(null);
+  interface EnrollmentWithLearner extends Enrollment {
+    learner?: Learner;
+  }
+  const [selectedLearner, setSelectedLearner] = useState<EnrollmentWithLearner | null>(null);
   const [rubric, setRubric] = useState<PracticalRubric>({
     cpr_aed: {
       ppe: false,

--- a/src/pages/CoursePreview.tsx
+++ b/src/pages/CoursePreview.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import {
+  Clock,
+  CheckCircle2,
+  XCircle,
+} from 'lucide-react';
+import { mockQuestions, type Question } from '@/lib/mockData';
+
+interface ContentStep {
+  type: 'content';
+  title: string;
+  body: string;
+}
+
+interface QuizStep {
+  type: 'quiz';
+  title: string;
+  shuffle?: boolean;
+  duration: number; // seconds
+  questionCount?: number;
+}
+
+type Step = ContentStep | QuizStep;
+
+const courseSteps: Step[] = [
+  {
+    type: 'content',
+    title: 'Course Introduction',
+    body: 'This preview simulates the course flow a learner would experience. Use the next button to proceed through content and assessments.',
+  },
+  {
+    type: 'quiz',
+    title: 'Assessment',
+    shuffle: true,
+    duration: 5 * 60,
+    questionCount: 5,
+  },
+];
+
+const formatTime = (seconds: number) => {
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${minutes}:${secs.toString().padStart(2, '0')}`;
+};
+
+const CoursePreview = () => {
+  const { courseId } = useParams();
+  const navigate = useNavigate();
+  const [stepIndex, setStepIndex] = useState(0);
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+  const [answers, setAnswers] = useState<number[]>([]);
+  const [timeRemaining, setTimeRemaining] = useState(0);
+  const [result, setResult] = useState<{ score: number; passed: boolean } | null>(null);
+
+  const step = courseSteps[stepIndex];
+
+  useEffect(() => {
+    if (step.type === 'quiz') {
+      let qs = [...mockQuestions];
+      if (step.shuffle) {
+        qs = qs.sort(() => Math.random() - 0.5);
+      }
+      const count = step.questionCount ?? qs.length;
+      qs = qs.slice(0, Math.min(count, qs.length));
+      setQuestions(qs);
+      setAnswers(new Array(qs.length).fill(-1));
+      setCurrentQuestionIndex(0);
+      setResult(null);
+      setTimeRemaining(step.duration);
+    }
+  }, [step]);
+
+  useEffect(() => {
+    if (step.type === 'quiz' && timeRemaining > 0 && !result) {
+      const timer = setInterval(() => {
+        setTimeRemaining((prev) => {
+          if (prev <= 1) {
+            handleSubmit();
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+      return () => clearInterval(timer);
+    }
+  }, [step, timeRemaining, result, handleSubmit]);
+
+  const handleAnswerSelect = (index: number) => {
+    const newAnswers = [...answers];
+    newAnswers[currentQuestionIndex] = index;
+    setAnswers(newAnswers);
+  };
+
+  const handleNextQuestion = () => {
+    if (currentQuestionIndex < questions.length - 1) {
+      setCurrentQuestionIndex((prev) => prev + 1);
+    }
+  };
+
+  const handlePrevQuestion = () => {
+    if (currentQuestionIndex > 0) {
+      setCurrentQuestionIndex((prev) => prev - 1);
+    }
+  };
+
+  const handleSubmit = useCallback(() => {
+    let correct = 0;
+    questions.forEach((q, i) => {
+      if (answers[i] === q.correctIndex) correct++;
+    });
+    const score = Math.round((correct / questions.length) * 100);
+    setResult({ score, passed: score >= 80 });
+  }, [answers, questions]);
+
+  const restartPreview = () => {
+    setStepIndex(0);
+    setResult(null);
+  };
+
+  return (
+    <div className="min-h-screen bg-background p-4">
+      <div className="max-w-3xl mx-auto space-y-4">
+        <div className="flex items-center justify-between">
+          <Button variant="outline" onClick={() => navigate(-1)}>
+            Back
+          </Button>
+          <span className="text-sm text-muted-foreground">Course {courseId} preview</span>
+        </div>
+
+        {step.type === 'content' && (
+          <Card>
+            <CardHeader>
+              <CardTitle>{step.title}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p>{step.body}</p>
+              <Button onClick={() => setStepIndex(stepIndex + 1)}>Next</Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {step.type === 'quiz' && (
+          <>
+            {result ? (
+              <Card className="text-center">
+                <CardHeader>
+                  <div
+                    className={`mx-auto h-16 w-16 rounded-full flex items-center justify-center mb-4 ${
+                      result.passed ? 'bg-success/10' : 'bg-destructive/10'
+                    }`}
+                  >
+                    {result.passed ? (
+                      <CheckCircle2 className="h-8 w-8 text-success" />
+                    ) : (
+                      <XCircle className="h-8 w-8 text-destructive" />
+                    )}
+                  </div>
+                  <CardTitle>
+                    {result.passed ? 'Assessment Passed' : 'Assessment Failed'}
+                  </CardTitle>
+                  <CardDescription>
+                    Score: {result.score}% ({Math.round((result.score / 100) * questions.length)}/{questions.length} correct)
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <Button onClick={restartPreview} variant="outline">
+                    Restart Preview
+                  </Button>
+                  <Button onClick={() => navigate(-1)}>Close</Button>
+                </CardContent>
+              </Card>
+            ) : (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center justify-between">
+                    <span>{step.title}</span>
+                    <div className="flex items-center gap-2 text-sm">
+                      <Clock className="h-4 w-4" />
+                      {formatTime(timeRemaining)}
+                    </div>
+                  </CardTitle>
+                  <CardDescription>
+                    Question {currentQuestionIndex + 1} of {questions.length}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <Progress value={((currentQuestionIndex + 1) / questions.length) * 100} />
+                  <div className="space-y-3">
+                    {questions[currentQuestionIndex]?.choices.map((choice, idx) => (
+                      <button
+                        key={idx}
+                        onClick={() => handleAnswerSelect(idx)}
+                        className={`w-full p-4 text-left rounded-lg border-2 transition-all hover:bg-muted/50 ${
+                          answers[currentQuestionIndex] === idx
+                            ? 'border-primary bg-primary/5'
+                            : 'border-border'
+                        }`}
+                      >
+                        <div className="flex items-center gap-3">
+                          <div
+                            className={`w-6 h-6 rounded-full border-2 flex items-center justify-center ${
+                              answers[currentQuestionIndex] === idx
+                                ? 'border-primary bg-primary text-primary-foreground'
+                                : 'border-muted-foreground'
+                            }`}
+                          >
+                            {String.fromCharCode(65 + idx)}
+                          </div>
+                          <span className="text-lg">{choice}</span>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+
+                  <div className="flex justify-between mt-4">
+                    <Button
+                      variant="outline"
+                      onClick={handlePrevQuestion}
+                      disabled={currentQuestionIndex === 0}
+                    >
+                      Previous
+                    </Button>
+                    {currentQuestionIndex === questions.length - 1 ? (
+                      <Button
+                        onClick={handleSubmit}
+                        disabled={answers.some((a) => a === -1)}
+                        className="bg-success hover:bg-success/90"
+                      >
+                        Submit
+                      </Button>
+                    ) : (
+                      <Button
+                        onClick={handleNextQuestion}
+                        disabled={answers[currentQuestionIndex] === -1}
+                      >
+                        Next
+                      </Button>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CoursePreview;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,20 +1,21 @@
 import { useState } from 'react';
 import { useAuth } from '@/lib/auth';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { StatusBadge } from '@/components/StatusBadge';
-import { 
-  Users, 
-  Calendar, 
-  Upload, 
-  Download, 
-  FileText, 
+import {
+  Users,
+  Calendar,
+  Upload,
+  Download,
+  FileText,
   Shield,
   LogOut,
   Plus,
-  BarChart3
+  BarChart3,
+  Eye
 } from 'lucide-react';
 import { mockCohorts, getCohortEnrollments } from '@/lib/mockData';
 import { useToast } from '@/hooks/use-toast';
@@ -22,6 +23,7 @@ import { useToast } from '@/hooks/use-toast';
 const Dashboard = () => {
   const { user, logout } = useAuth();
   const { toast } = useToast();
+  const navigate = useNavigate();
   const [selectedCohort] = useState(mockCohorts[0]);
 
   if (!user) {
@@ -59,6 +61,10 @@ const Dashboard = () => {
     });
   };
 
+  const handlePreviewCourse = () => {
+    navigate('/admin/courses/1/preview');
+  };
+
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
@@ -91,7 +97,7 @@ const Dashboard = () => {
       <div className="container mx-auto px-4 py-8 space-y-8">
         {/* Quick Actions */}
         {user.role === 'ADMIN' && (
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
             <Card className="border-primary/20 hover:shadow-lg transition-shadow cursor-pointer" onClick={handleCreateCohort}>
               <CardContent className="p-6 text-center">
                 <Plus className="h-8 w-8 text-primary mx-auto mb-2" />
@@ -115,12 +121,20 @@ const Dashboard = () => {
                 <p className="text-sm text-muted-foreground">Download CSV + certificates</p>
               </CardContent>
             </Card>
-            
+
             <Card className="border-accent/20 hover:shadow-lg transition-shadow">
               <CardContent className="p-6 text-center">
                 <FileText className="h-8 w-8 text-accent mx-auto mb-2" />
                 <h3 className="font-semibold">Certificate Register</h3>
                 <p className="text-sm text-muted-foreground">Manage issued certificates</p>
+              </CardContent>
+            </Card>
+
+            <Card className="border-secondary/20 hover:shadow-lg transition-shadow cursor-pointer" onClick={handlePreviewCourse}>
+              <CardContent className="p-6 text-center">
+                <Eye className="h-8 w-8 text-secondary mx-auto mb-2" />
+                <h3 className="font-semibold">Preview Course</h3>
+                <p className="text-sm text-muted-foreground">Simulate course flow</p>
               </CardContent>
             </Card>
           </div>

--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -7,7 +7,7 @@ import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import { Clock, User, CheckCircle2, XCircle, AlertTriangle } from 'lucide-react';
-import { mockQuestions, mockLearners, type Question } from '@/lib/mockData';
+import { mockQuestions, mockLearners, type Question, type Learner } from '@/lib/mockData';
 import { useToast } from '@/hooks/use-toast';
 
 type KioskStep = 'badge-input' | 'quiz' | 'complete';
@@ -20,7 +20,7 @@ const Kiosk = () => {
   
   const [step, setStep] = useState<KioskStep>('badge-input');
   const [badgeId, setBadgeId] = useState('');
-  const [currentLearner, setCurrentLearner] = useState<any>(null);
+  const [currentLearner, setCurrentLearner] = useState<Learner | null>(null);
   const [questions, setQuestions] = useState<Question[]>([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [answers, setAnswers] = useState<number[]>([]);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -101,5 +102,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add admin course preview route and page with content and randomized assessments
- add dashboard quick action to launch course preview
- switch tailwind config to ES module plugin import and fix lint issues

## Testing
- `npm test -- --run` (fails: No test files found)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68baec411e04832abb33394a09a85094